### PR TITLE
feat: Alias for PowerShell [Comment]

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,18 @@ For Linux/MacOS systems:
 ```
 
 or you can set an alias:
+
+For Windows PowerShell:
+```commandline
+    function dx-tools { python 'C:\<path>\aps-dx-tools-python\main.py' @args }
 ```
-alias dx-tools="python3 main.py"
+To make the alias permanent, add the function to your PowerShell profile (`$PROFILE`).
+
+For Linux/MacOS systems:
+```commandline
+    alias dx-tools="python3 main.py"
 ```
+To make the alias permanent, add it to `~/.bashrc` or `~/.zshrc`.
 
 and call the app with further commands:
 


### PR DESCRIPTION
Closes #1

# PowerShell Alias Documentation Implementation Plan

## Overview

Add a Windows PowerShell alias example to `README.md` so that Windows users can set up the `dx-tools` shortcut the same way Linux/macOS users can. The existing bash-only alias section (lines 56-59) will be split into OS-specific branches following the established pattern already present in the README (lines 37-44).

## Current State Analysis

### Key Discoveries:
- `README.md:56-59` — current alias section has a single bash alias (`alias dx-tools="python3 main.py"`) with no Windows/PowerShell equivalent
- `README.md:37-44` — the venv activation section already uses the exact pattern to follow: plain-text `For Windows:` / `For Linux/MacOS systems:` labels, each followed by a ` ```commandline ` fenced block with 4-space indentation
- PowerShell `Set-Alias` cannot embed arguments, so a wrapper function using `@args` splatting is required — the issue author's snippet demonstrates the correct approach
- PowerShell allows hyphens in function names, so `function dx-tools { ... }` works directly without a separate `Set-Alias` step
- The existing bash code block uses a bare fence (no info string, no indentation) which differs from the style used elsewhere — it should be normalized

## Desired End State

`README.md` section starting at line 56 reads:

```
or you can set an alias:

For Windows PowerShell:
```commandline
    function dx-tools { python 'C:\<path>\aps-dx-tools-python\main.py' @args }
```
To make the alias permanent, add the function to your PowerShell profile (`$PROFILE`).

For Linux/MacOS systems:
```commandline
    alias dx-tools="python3 main.py"
```
To make the alias permanent, add it to `~/.bashrc` or `~/.zshrc`.
```

**Verification:** `README.md` renders correctly on GitHub with two labeled OS-specific code blocks in the alias section, consistent styling with lines 37-44, and the `dx-tools gethubs` example below still makes sense.

## What We're NOT Doing

- Not changing any Python source files, tests, or configuration
- Not adding a `.ps1` profile script or any new files to the repo
- Not changing the `Set-Alias` pattern suggested in the issue (choosing the simpler function-only approach instead, per research findings)
- Not restructuring other sections of the README beyond the alias block

## Implementation Approach

Single-file edit to `README.md` lines 56-59: replace the bare bash-only alias block with a two-branch OS-specific section following the exact pattern from lines 37-44. Add a one-line persistence note under each code block.

---

**IMPORTANT: Checkboxes are for implementation steps only.**

### TASK 1: Update alias section in README.md [HIGH PRIORITY]
**Status:** DONE
**Milestone:** `README.md` alias section covers both Windows PowerShell and Linux/macOS, with consistent formatting matching the rest of the document

- [x] Open `README.md` and locate the alias section at lines 56-59 (text: `or you can set an alias:` followed by the bare-fenced bash alias block)
- [x] Replace lines 57-59 (the bare ` ``` ` ... ` ``` ` block) with an OS-branched section:
  - Add blank line after `or you can set an alias:`
  - Add `For Windows PowerShell:` label
  - Add ` ```commandline ` fenced block containing `    function dx-tools { python 'C:\<path>\aps-dx-tools-python\main.py' @args }` (4-space indentation inside fence)
  - Add persistence note: `To make the alias permanent, add the function to your PowerShell profile (\`$PROFILE\`).`
  - Add blank line separator
  - Add `For Linux/MacOS systems:` label
  - Add ` ```commandline ` fenced block containing `    alias dx-tools="python3 main.py"` (4-space indentation inside fence, `commandline` info string)
  - Add persistence note: `To make the alias permanent, add it to \`~/.bashrc\` or \`~/.zshrc\`.`
- [x] Verify the lines immediately following (the `and call the app with further commands:` paragraph and `dx-tools gethubs` example) are unchanged and still follow naturally

**Validation:** Run `grep -n "dx-tools\|PowerShell\|bashrc\|commandline" README.md` and confirm the new OS-specific labels and `commandline` info strings appear in the alias section; confirm no unintended changes elsewhere.

**Requirements from spec:**
- Windows PowerShell users need a working alias/function that forwards all arguments to `python main.py`
- The solution must follow the existing OS-branching style in the document (lines 37-44)
- `@args` splatting must be used to correctly forward positional arguments

**Files to Modify:**
- `README.md` — Replace bare bash-only alias block (lines 57-59) with two OS-specific labeled code blocks and persistence notes

**Implementation Details:**
- Use `python` (not `python3`) in the PowerShell block — Windows typically ships with `python` on PATH
- Use `python3` in the Linux/macOS block — consistent with the existing content
- The `<path>` placeholder in the Windows function should remain a placeholder (same style as the original issue suggestion) since the install location varies by user
- No other files need to be created or modified

---

## Testing Strategy

### Unit Tests:
- N/A — documentation-only change, no code logic to unit test

### Integration Tests:
- N/A — no code changes

### Manual Testing Steps:
1. Preview `README.md` on GitHub (or a local Markdown renderer) and confirm both OS-specific alias blocks render with correct syntax highlighting and indentation
2. On a Windows machine with PowerShell, paste the function into a terminal and verify `dx-tools gethubs` correctly invokes `python main.py gethubs`
3. On Linux/macOS, run `alias dx-tools="python3 main.py"` and verify `dx-tools gethubs` works as expected
4. Confirm the persistence notes are accurate: adding the function to `$PROFILE` on Windows and to `~/.bashrc`/`~/.zshrc` on Linux/macOS survives a new shell session

## Performance Considerations

None — this is a documentation-only change with no runtime impact.